### PR TITLE
Feature/transmission control options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ EFax::Request.account_id = <your account id>
 EFax::Request.user       = <your login>
 EFax::Request.password   = <your password>
 ```
+
 Sending an HTML page using eFax service is pretty simple:
 
 ```ruby
@@ -62,6 +63,17 @@ response = EFax::OutboundRequest.post(recipient_name, company_name, fax_number, 
 
 See `EFax::RequestStatus` class for details on status codes.
 
+Configuring Transmission:
+
+Transmission options may be set similarly to the basic account credentials, through the `TransmissionControlOptions` object. The default values are shown below.
+
+```ruby
+EFax::Request.transmission_control_options = EFax::TransmissionControlOptions.new(
+    resolution: 'FINE',
+    priority: 'NORMAL',
+    self_busy: 'ENABLE',
+)
+```
 
 Having ID of your request, you can get its current status:
 

--- a/lib/efax/outbound.rb
+++ b/lib/efax/outbound.rb
@@ -31,6 +31,27 @@ module EFax
       @priority   = options[:priority] || 'NORMAL'
       @self_busy  = options[:self_busy] || 'ENABLE'
     end
+
+    def resolution
+      @resolution
+    end
+    def resolution=(resolution)
+      @resolution = resolution
+    end
+
+    def priority
+      @priority
+    end
+    def priority=(priority)
+      @priority = priority
+    end
+
+    def self_busy
+      @self_busy
+    end
+    def self_busy=(self_busy)
+      @self_busy = self_busy
+    end
   end
 
   # Base class for OutboundRequest and OutboundStatus classes
@@ -57,8 +78,8 @@ module EFax
     end
 
     def self.transmission_control_options
-      @@transmission_control_options = default_transmission_control_options if @@transmission_control_options.nil?
-      @@transmission_control_options
+      # @@transmission_control_options = default_transmission_control_options if @@transmission_control_options.nil?
+      @@transmission_control_options ||= default_transmission_control_options
     end
     def self.transmission_control_options=(options)
       @@transmission_control_options = options
@@ -95,9 +116,9 @@ module EFax
         end
         xml.Transmission do
           xml.TransmissionControl do
-            xml.Resolution(transmission_control_options.resolution)
-            xml.Priority(transmission_control_options.priority)
-            xml.SelfBusy(transmission_control_options.self_busy)
+            xml.Resolution(self.transmission_control_options.resolution)
+            xml.Priority(self.transmission_control_options.priority)
+            xml.SelfBusy(self.transmission_control_options.self_busy)
             xml.FaxHeader(subject)
           end
           xml.DispositionControl do

--- a/lib/efax/outbound.rb
+++ b/lib/efax/outbound.rb
@@ -23,6 +23,8 @@ module EFax
   # Prefered content type
   HEADERS  = {'Content-Type' => 'text/xml'}
 
+  OUTBOUND_RESOLUTION = ENV['EFAX_OUTBOUND_RESOLUTION'] || "FINE"
+
   # Base class for OutboundRequest and OutboundStatus classes
   class Request
     def self.user
@@ -74,7 +76,7 @@ module EFax
         end
         xml.Transmission do
           xml.TransmissionControl do
-            xml.Resolution("FINE")
+            xml.Resolution(OUTBOUND_RESOLUTION)
             xml.Priority("NORMAL")
             xml.SelfBusy("ENABLE")
             xml.FaxHeader(subject)

--- a/lib/efax/outbound.rb
+++ b/lib/efax/outbound.rb
@@ -25,6 +25,14 @@ module EFax
 
   OUTBOUND_RESOLUTION = ENV['EFAX_OUTBOUND_RESOLUTION'] || "FINE"
 
+  class TransmissionControlOptions
+    def initialize(options={})
+      @resolution = options[:resolution] || 'FINE'
+      @priority   = options[:priority] || 'NORMAL'
+      @self_busy  = options[:self_busy] || 'ENABLE'
+    end
+  end
+
   # Base class for OutboundRequest and OutboundStatus classes
   class Request
     def self.user
@@ -46,6 +54,17 @@ module EFax
     end
     def self.account_id=(id)
       @@account_id = id
+    end
+
+    def self.transmission_control_options
+      @@transmission_control_options = default_transmission_control_options if @@transmission_control_options.nil?
+      @@transmission_control_options
+    end
+    def self.transmission_control_options=(options)
+      @@transmission_control_options = options
+    end
+    def self.default_transmission_control_options
+      TransmissionControlOptions.new
     end
 
     def self.params(content)
@@ -76,9 +95,9 @@ module EFax
         end
         xml.Transmission do
           xml.TransmissionControl do
-            xml.Resolution(OUTBOUND_RESOLUTION)
-            xml.Priority("NORMAL")
-            xml.SelfBusy("ENABLE")
+            xml.Resolution(transmission_control_options.resolution)
+            xml.Priority(transmission_control_options.priority)
+            xml.SelfBusy(transmission_control_options.self_busy)
             xml.FaxHeader(subject)
           end
           xml.DispositionControl do

--- a/lib/efax/outbound.rb
+++ b/lib/efax/outbound.rb
@@ -78,7 +78,6 @@ module EFax
     end
 
     def self.transmission_control_options
-      # @@transmission_control_options = default_transmission_control_options if @@transmission_control_options.nil?
       @@transmission_control_options ||= default_transmission_control_options
     end
     def self.transmission_control_options=(options)

--- a/test/efax_outbound_test.rb
+++ b/test/efax_outbound_test.rb
@@ -159,7 +159,7 @@ module EFaxOutboundTest
       assert_equal EFax::QueryStatus::SENT, response.status_code
     end
 
-        def test_busy_response
+    def test_busy_response
       xml = <<-XML
         <?xml version="1.0"?>
         <OutboundStatusResponse>
@@ -471,6 +471,51 @@ module EFaxOutboundTest
       EFax::Request.password = "moes"
       EFax::OutboundRequest.publicize_class_methods do
         assert_equal expected_xml.delete(" "), EFax::OutboundRequest.xml("I. P. Freely", "Moe's", "12345678901", "Subject", "<html><body><h1>Test</h1></body></html>", :html, disposition).delete(" ")
+      end
+    end
+    def test_generate_xml_transmission_control_options
+      expected_xml = <<-XML
+        <?xml version="1.0" encoding="UTF-8"?>
+          <OutboundRequest>
+            <AccessControl>
+              <UserName>Mike Rotch</UserName>
+              <Password>moes</Password>
+            </AccessControl>
+            <Transmission>
+              <TransmissionControl>
+                <Resolution>STANDARD</Resolution>
+                <Priority>HIGH</Priority>
+                <SelfBusy>DISABLE</SelfBusy>
+                <FaxHeader>Subject</FaxHeader>
+              </TransmissionControl>
+            <DispositionControl>
+              <DispositionLevel>NONE</DispositionLevel>
+            </DispositionControl>
+            <Recipients>
+              <Recipient>
+                <RecipientName>I. P. Freely</RecipientName>
+                <RecipientCompany>Moe's</RecipientCompany>
+                <RecipientFax>12345678901</RecipientFax>
+              </Recipient>
+            </Recipients>
+            <Files>
+              <File>
+                <FileContents>PGh0bWw+PGJvZHk+PGgxPlRlc3Q8L2gxPjwvYm9keT48L2h0bWw+</FileContents>
+                <FileType>html</FileType>
+              </File>
+            </Files>
+          </Transmission>
+        </OutboundRequest>
+      XML
+      EFax::Request.user = "Mike Rotch"
+      EFax::Request.password = "moes"
+      EFax::Request.transmission_control_options = EFax::TransmissionControlOptions.new(
+        resolution: 'STANDARD',
+        priority: 'HIGH',
+        self_busy: 'DISABLE'
+      )
+      EFax::OutboundRequest.publicize_class_methods do
+        assert_equal expected_xml.delete(" "), EFax::OutboundRequest.xml("I. P. Freely", "Moe's", "12345678901", "Subject", "<html><body><h1>Test</h1></body></html>").delete(" ")
       end
     end
   end


### PR DESCRIPTION
Adds support for configurable `TransmissionControlOptions` for outbound requests. Unlike the other configs, these options are, in fact, optional, and the default behavior will be used if for any of them that are unset.